### PR TITLE
Remove un-used locals variable

### DIFF
--- a/app/views/spree/admin/products/index.html.erb
+++ b/app/views/spree/admin/products/index.html.erb
@@ -10,7 +10,6 @@
   <div data-hook="admin_products_sidebar">
 
     <%= search_form_for [:admin, @search] do |f| %>
-      <%- locals = {f: f} %>
       <div data-hook="admin_products_index_search" class="row">
         <div class="col-12 col-lg-6">
           <div class="form-group">


### PR DESCRIPTION
![Screen Shot 2021-12-28 at 3 54 51 PM](https://user-images.githubusercontent.com/23930/147542556-9d098ee7-d7be-43fc-9976-f08aa9cc89eb.png)

This locals variable is not used anywhere right now, it was previously used in the hook method which no longer exists.